### PR TITLE
Add Destroy method to VMSteppable

### DIFF
--- a/bindings/go/evmc/evmc.go
+++ b/bindings/go/evmc/evmc.go
@@ -278,6 +278,10 @@ func (vm *VMSteppable) GetBaseHandle() unsafe.Pointer {
 	return unsafe.Pointer(vm.handle.vm)
 }
 
+func (vm *VMSteppable) Destroy() {
+	C.evmc_destroy(vm.handle.vm)
+}
+
 type Result struct {
 	Output    []byte
 	GasLeft   int64


### PR DESCRIPTION
This allows go code to carry out de-initialization routines.

Tosca will never release C++ memory or execute de-initialization routines because there is no interface for it. This has been tested by calling abort in the c++  destroy callback and then running the driver: No panic triggered. 

The code is inspired by the vanilla interface, using the same Destroy prototype. 

This PR was discovered during coverage studies, where dumping the coverage needs to be done manually.


