### PR TITLE
rust bindings: fix UB & implement conversion

### DIFF
--- a/bindings/rust/evmc-vm/src/lib.rs
+++ b/bindings/rust/evmc-vm/src/lib.rs
@@ -694,7 +694,7 @@ impl From<StepResult> for ffi::evmc_step_result {
     }
 }
 
-/// Returns a pointer to a stack-allocated evmc_step_result.
+/// Converts ffi type into steppable interface result type.
 impl From<ffi::evmc_step_result> for StepResult {
     fn from(value: ffi::evmc_step_result) -> Self {
         let ret = Self {

--- a/bindings/rust/evmc-vm/src/lib.rs
+++ b/bindings/rust/evmc-vm/src/lib.rs
@@ -755,7 +755,7 @@ impl From<ffi::evmc_step_result> for StepResult {
             },
         };
 
-        // Release allocated ffi struct.
+        // If release function is provided, use it to release resources.
         if let Some(release) = value.release {
             unsafe {
                 release(&value);


### PR DESCRIPTION
This PR fixes undefined behavior found by miri (allocations of size 0).

It also implements the conversion evmc_step_result -> StepResult and makes all fields of ExecutionResult and StepResult public. The conversions from evmc_result/ evmc_step_result to ExecutionResult/ StepResult are useful to make sure data is deallocated properly, but they only make sense if the types are actually useful, which is only the case if the fields are accessible.