### PR TITLE
rust bindings: use repr(C) for container types

### DIFF
--- a/bindings/rust/evmc-vm/src/container.rs
+++ b/bindings/rust/evmc-vm/src/container.rs
@@ -7,6 +7,7 @@ use crate::EvmcVm;
 use std::ops::{Deref, DerefMut};
 
 /// Container struct for EVMC instances and user-defined data.
+#[repr(C)]
 pub struct EvmcContainer<T>
 where
     T: EvmcVm + Sized,
@@ -67,6 +68,7 @@ where
 }
 
 /// Container struct for steppable EVMC instances and user-defined data.
+#[repr(C)]
 pub struct SteppableEvmcContainer<T>
 where
     T: EvmcVm + Sized,


### PR DESCRIPTION
This PR enforces C memory layout for the container types.

The container types hold an evmc_vm (a struct with function pointers for execute, set_options, ...) and a vm instance (in case of evmrs this is EvmRs). Because the evmc interface expects a pointer to an evmc_vm, the pointer to the container is cast to an evmc_vm pointer. 

However, this only works if the evmc_vm field is the first field in the container struct. With Rust memory layout this is not guaranteed. In fact, if EvmRs has an alignment > 8 (and therefore larger than that of evmc_vm), it will immediately crash.

By enforcing C memory layout, it is guaranteed that the first field is always the evmc_vm.